### PR TITLE
Fix theme radius tokens to use Intent UI values

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -88,10 +88,10 @@ code {
   --color-card: var(--card);
   --color-foreground: var(--foreground);
   --color-background: var(--background);
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  --radius-sm: var(--radius-sm);
+  --radius-md: var(--radius-md);
+  --radius-lg: var(--radius-lg);
+  --radius-xl: var(--radius-xl);
 }
 
 :root {


### PR DESCRIPTION
## Summary
- map the `@theme inline` radius tokens to the custom Intent UI radius variables

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908b91496d4833383502b91350f120e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal styling token calculations for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->