### PR TITLE
Relocate Typst export trigger to options panel

### DIFF
--- a/_docs/log/20251104_typst-export-modal.md
+++ b/_docs/log/20251104_typst-export-modal.md
@@ -1,0 +1,45 @@
+# Typst export modal
+
+- Date: 2025-11-04
+
+## Purpose
+
+Add a UI flow that lets users export the current table as Typst code and preview/copy it from a modal dialog.
+
+## Plan / TODO
+
+- [x] Review existing table export helpers and store state needed for Typst output
+- [x] Design the modal trigger + layout using Intent UI components
+- [x] Implement selectors/helpers to format the current table with wrap/escape options
+- [x] Render the modal with code preview and copy interaction, wiring into the toolbar
+- [x] Exercise basic manual verification of the modal and update notes
+
+## Notes (随時追記)
+
+- 設計・検討メモ:
+  - 既存の `renderTable` と `renderFigure` をそのまま使い、ストアの書式オプションセットをそのまま渡すだけで Typst 出力に反映できた。
+- Modal は Intent UI の `Modal` ラッパーを使い、ヘッダー/ボディ/フッターのスロットを活用した。
+- 気づき/意思決定:
+  - コードをコピーした後にテーブルを編集すると状態がズレないよう、Typst スニペットが更新されたタイミングでコピー状態をリセットする処理を追加。
+  - クリップボード API が使えない環境向けに `execCommand` ベースのフォールバックを用意し、失敗時は UI 上でエラー表示に切り替える。
+- 困りごと/対応:
+  - Biome の hook 依存関係 lint を避けるため、依存値を明示的に参照する（`void typstCode`）形でエフェクトを調整した。
+
+## Summary
+
+- エクスポートオプションパネルのヘッダーに Typst エクスポートモーダルのトリガーを配置し、関連設定と同じセクションで開けるようにした。
+- Intent UI の Modal コンポーネントでプレビュー UI を構築し、テーブルや図ラップ設定を反映した Typst コードをモノスペース表示。
+- コピーボタンに成功/失敗フィードバックとクリップボード API フォールバックを備え、エクスポートオプションの説明テキストも添えた。
+
+## Next (必要に応じて)
+
+- 次にやること/残課題
+
+## Reflection (感想)
+
+- Intent UI のモーダル構成が柔軟で助かった一方、まだツールバー自体が仮のため全体レイアウトの磨き込み余地を感じた。
+
+## Pre-PR Checklist
+
+- [x] `_docs/spec.md`に必要な変更を反映済み（不要な場合もこの文章を確認したらチェック）
+- [x] PR 本文にこのログへのリンクを含めることを確認

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import type {
+  DialogProps,
+  DialogTriggerProps,
+  ModalOverlayProps,
+} from "react-aria-components";
+import {
+  DialogTrigger as DialogTriggerPrimitive,
+  ModalOverlay,
+  Modal as ModalPrimitive,
+} from "react-aria-components";
+import { twJoin } from "tailwind-merge";
+import { cx } from "@/lib/primitive";
+import {
+  Dialog,
+  DialogBody,
+  DialogClose,
+  DialogCloseIcon,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "./dialog";
+
+const Modal = (props: DialogTriggerProps) => {
+  return <DialogTriggerPrimitive {...props} />;
+};
+
+const sizes = {
+  "2xs": "sm:max-w-2xs",
+  xs: "sm:max-w-xs",
+  sm: "sm:max-w-sm",
+  md: "sm:max-w-md",
+  lg: "sm:max-w-lg",
+  xl: "sm:max-w-xl",
+  "2xl": "sm:max-w-2xl",
+  "3xl": "sm:max-w-3xl",
+  "4xl": "sm:max-w-4xl",
+  "5xl": "sm:max-w-5xl",
+  fullscreen: "",
+} as const;
+
+interface ModalContentProps
+  extends Omit<ModalOverlayProps, "className" | "children">,
+    Pick<DialogProps, "aria-label" | "aria-labelledby" | "role" | "children"> {
+  size?: keyof typeof sizes;
+  closeButton?: boolean;
+  isBlurred?: boolean;
+  className?: ModalOverlayProps["className"];
+  overlay?: Omit<ModalOverlayProps, "children">;
+}
+
+const ModalContent = ({
+  className,
+  isDismissable: isDismissableInternal,
+  isBlurred = false,
+  children,
+  overlay,
+  size = "lg",
+  role = "dialog",
+  closeButton = true,
+  ...props
+}: ModalContentProps) => {
+  const isDismissable = isDismissableInternal ?? role !== "alertdialog";
+
+  return (
+    <ModalOverlay
+      data-slot="modal-overlay"
+      isDismissable={isDismissable}
+      className={twJoin(
+        "fixed inset-0 z-50 h-(--visual-viewport-height,100vh) bg-black/15",
+        "grid grid-rows-[1fr_auto] justify-items-center sm:grid-rows-[1fr_auto_3fr]",
+        size === "fullscreen" ? "md:p-3" : "md:p-4",
+        "entering:fade-in entering:animate-in entering:duration-300 entering:ease-out",
+        "exiting:fade-out exiting:animate-out exiting:ease-in",
+        isBlurred && "backdrop-blur-[1px] backdrop-filter",
+      )}
+      {...props}
+    >
+      <ModalPrimitive
+        data-slot="modal-content"
+        className={cx(
+          "row-start-2 w-full text-left align-middle",
+          "[--visual-viewport-vertical-padding:16px]",
+          size === "fullscreen"
+            ? "sm:rounded-md sm:[--visual-viewport-vertical-padding:16px]"
+            : "sm:rounded-xl sm:[--visual-viewport-vertical-padding:32px]",
+          "relative overflow-hidden bg-overlay text-overlay-fg",
+          "rounded-t-2xl shadow-lg ring ring-fg/5 dark:ring-border",
+          sizes[size],
+          "entering:slide-in-from-bottom sm:entering:zoom-in-95 sm:entering:slide-in-from-bottom-0 entering:animate-in entering:duration-300 entering:ease-out",
+          "exiting:slide-out-to-bottom sm:exiting:zoom-out-95 sm:exiting:slide-out-to-bottom-0 exiting:animate-out exiting:ease-in",
+          className,
+        )}
+        {...props}
+      >
+        <Dialog role={role}>
+          {(values) => (
+            <>
+              {typeof children === "function" ? children(values) : children}
+              {closeButton && <DialogCloseIcon isDismissable={isDismissable} />}
+            </>
+          )}
+        </Dialog>
+      </ModalPrimitive>
+    </ModalOverlay>
+  );
+};
+
+const ModalTrigger = DialogTrigger;
+const ModalHeader = DialogHeader;
+const ModalTitle = DialogTitle;
+const ModalDescription = DialogDescription;
+const ModalFooter = DialogFooter;
+const ModalBody = DialogBody;
+const ModalClose = DialogClose;
+
+export type { ModalContentProps };
+export {
+  Modal,
+  ModalBody,
+  ModalClose,
+  ModalContent,
+  ModalDescription,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+  ModalTrigger,
+};

--- a/src/features/table-editor/components/ExportOptionsPanel.tsx
+++ b/src/features/table-editor/components/ExportOptionsPanel.tsx
@@ -23,6 +23,7 @@ import {
   wrapFigureEnabledSelector,
   wrapFigureOptionsSelector,
 } from "../store";
+import { TypstExportModal } from "./TypstExportModal";
 
 const ESCAPE_INLINE_MARKERS = ["#", "$", "[", "]", "@"] as const;
 
@@ -98,7 +99,10 @@ export function ExportOptionsPanel() {
   return (
     <Card className="max-w-sm">
       <CardHeader>
-        <CardTitle>Export options</CardTitle>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <CardTitle>Export options</CardTitle>
+          <TypstExportModal />
+        </div>
       </CardHeader>
       <CardContent className="space-y-6">
         <Checkbox isSelected={escapeEnabled} onChange={handleEscapeToggle}>

--- a/src/features/table-editor/components/GridToolBar.tsx
+++ b/src/features/table-editor/components/GridToolBar.tsx
@@ -78,7 +78,6 @@ export function GridToolBar() {
     </Toolbar>
   );
 }
-
 type ToolbarGroupProps = GroupProps & {
   groupHeader: string;
 };

--- a/src/features/table-editor/components/TypstExportModal.tsx
+++ b/src/features/table-editor/components/TypstExportModal.tsx
@@ -1,0 +1,162 @@
+import { IconCheck, IconCopy } from "@tabler/icons-react";
+import { useStore } from "@tanstack/react-store";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Modal,
+  ModalBody,
+  ModalClose,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@/components/ui/modal";
+import { renderFigure } from "@/domain/typst/figure";
+import { renderTable } from "@/domain/typst/table/render-table";
+import { cx } from "@/lib/primitive";
+import type { TableEditorState } from "../store";
+import {
+  tableEditorStore,
+  wrapFigureEnabledSelector,
+  wrapFigureOptionsSelector,
+} from "../store";
+
+const tableStateSelector = (state: TableEditorState) => state.table;
+const formattingOptionsSelector = (state: TableEditorState) =>
+  state.tableRenderingOptions;
+
+export function TypstExportModal() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [copyStatus, setCopyStatus] = useState<"idle" | "copied" | "error">(
+    "idle",
+  );
+
+  const table = useStore(tableEditorStore, tableStateSelector);
+  const wrapFigureEnabled = useStore(
+    tableEditorStore,
+    wrapFigureEnabledSelector,
+  );
+  const figureOptions = useStore(tableEditorStore, wrapFigureOptionsSelector);
+  const formattingOptions = useStore(
+    tableEditorStore,
+    formattingOptionsSelector,
+  );
+
+  const typstCode = useMemo(() => {
+    const tableSnippet = renderTable(table, formattingOptions);
+    if (wrapFigureEnabled) {
+      return renderFigure(tableSnippet, figureOptions);
+    }
+    return tableSnippet;
+  }, [figureOptions, formattingOptions, table, wrapFigureEnabled]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setCopyStatus("idle");
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    void typstCode;
+    setCopyStatus("idle");
+  }, [typstCode]);
+
+  useEffect(() => {
+    if (copyStatus !== "copied") {
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      setCopyStatus("idle");
+    }, 2000);
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [copyStatus]);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(typstCode);
+      } else {
+        const fallback = document.createElement("textarea");
+        fallback.value = typstCode;
+        fallback.style.position = "fixed";
+        fallback.style.opacity = "0";
+        document.body.appendChild(fallback);
+        fallback.focus();
+        fallback.select();
+        document.execCommand("copy");
+        document.body.removeChild(fallback);
+      }
+      setCopyStatus("copied");
+    } catch (error) {
+      console.error("Failed to copy Typst code", error);
+      setCopyStatus("error");
+    }
+  }, [typstCode]);
+
+  const copyLabel =
+    copyStatus === "copied"
+      ? "Copied"
+      : copyStatus === "error"
+        ? "Copy failed"
+        : "Copy to clipboard";
+
+  return (
+    <Modal isOpen={isOpen} onOpenChange={setIsOpen}>
+      <Button intent="primary" size="sm">
+        Export Typst
+      </Button>
+      <ModalContent
+        size="3xl"
+        isBlurred
+        aria-label="Typst export modal"
+        className={({ isEntering, isExiting }) =>
+          cx(
+            "max-w-4xl sm:max-w-3xl",
+            isEntering && "sm:animate-in sm:fade-in",
+            isExiting && "sm:animate-out sm:fade-out",
+          )
+        }
+      >
+        <ModalHeader
+          title="Export Typst code"
+          description="Preview and copy the generated Typst snippet."
+        />
+        <ModalBody className="space-y-4">
+          <Card>
+            <CardContent className="max-h-[60vh] overflow-auto bg-muted/40">
+              <pre className="whitespace-pre text-sm font-mono leading-6">
+                {typstCode}
+              </pre>
+            </CardContent>
+          </Card>
+        </ModalBody>
+        <ModalFooter className="flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <span aria-live="polite" className="text-sm text-muted-fg">
+            {copyStatus === "copied"
+              ? "Typst code copied to clipboard."
+              : copyStatus === "error"
+                ? "Failed to copy code."
+                : "Options from the export panel are applied automatically."}
+          </span>
+          <div className="flex items-center gap-3">
+            <ModalClose intent="plain">Close</ModalClose>
+            <Button
+              intent={copyStatus === "error" ? "danger" : "primary"}
+              size="sm"
+              onPress={handleCopy}
+            >
+              {copyStatus === "copied" ? (
+                <IconCheck className="size-4" aria-hidden />
+              ) : (
+                <IconCopy className="size-4" aria-hidden />
+              )}
+              <span className="ml-2">{copyLabel}</span>
+            </Button>
+          </div>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary
- remove the export group from the table editor toolbar so it only hosts table-manipulation controls
- add the Typst export modal trigger to the export options card header to keep it near its related settings
- refresh the work log summary to describe the new trigger placement

## Testing
- pnpm check
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_69099b04e0e48333bfbe3c78dab55244

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Typst export modal dialog enabling users to export table content as Typst code with live preview.
  * Integrated copy-to-clipboard functionality with automatic visual feedback for successful copy or error states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->